### PR TITLE
Allow passing ExecutorService to region task

### DIFF
--- a/src/main/java/omeis/providers/re/HSBStrategy.java
+++ b/src/main/java/omeis/providers/re/HSBStrategy.java
@@ -62,7 +62,18 @@ class HSBStrategy extends RenderingStrategy {
 	
     /** The logger for this particular class */
     private static Logger log = LoggerFactory.getLogger(HSBStrategy.class);
-    
+
+    /** Shared thread pool */
+    ExecutorService processor;
+
+    public HSBStrategy(ExecutorService processor) {
+        this.processor = processor;
+    }
+
+    public HSBStrategy(Object obj) {
+        this.processor = Executors.newCachedThreadPool();
+    }
+
     /**
      * Retrieves the maximum number of reasonable tasks to schedule based on
      * image size and <i>maxTasks</i>.
@@ -329,7 +340,6 @@ class HSBStrategy extends RenderingStrategy {
         performanceStats.startRendering();
         int n = tasks.length;
         Future[] rndTskFutures = new Future[n]; // [0] unused.
-        ExecutorService processor = Executors.newCachedThreadPool();
 
         while (0 < --n) {
             rndTskFutures[n] = processor.submit(tasks[n]);

--- a/src/main/java/omeis/providers/re/Renderer.java
+++ b/src/main/java/omeis/providers/re/Renderer.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -139,6 +141,11 @@ public class Renderer {
 
     /** Lookup table provider. */
     private LutProvider lutProvider;
+
+    /**
+     * Shared thread Pool
+     */
+    private ExecutorService processor;
 
     /**
      * Returns a copy of a list of channel bindings with one element removed;
@@ -354,10 +361,32 @@ public class Renderer {
     		List<RenderingModel> renderingModels, Pixels pixelsObj,
             RenderingDef renderingDefObj, PixelBuffer bufferObj,
             LutProvider lutProvider) {
+        this(quantumFactory, renderingModels, pixelsObj, renderingDefObj, bufferObj,
+                lutProvider, Executors.newCachedThreadPool());
+    }
+
+    /**
+     * Creates a new instance to render the specified pixels set and get this
+     * new instance ready for rendering.
+     *
+     * @param quantumFactory a populated quantum factory.
+     * @param renderingModels an enumerated list of all rendering models.
+     * @param pixelsObj Pixels object.
+     * @param renderingDefObj Rendering definition object.
+     * @param bufferObj PixelBuffer object.
+     * @param lutProvider provider of the available lookup tables.
+     * @param processor shared thread pool
+     * @throws NullPointerException If <code>null</code> parameters are passed.
+     */
+    public Renderer(QuantumFactory quantumFactory,
+                    List<RenderingModel> renderingModels, Pixels pixelsObj,
+                    RenderingDef renderingDefObj, PixelBuffer bufferObj,
+                    LutProvider lutProvider, ExecutorService processor) {
         metadata = pixelsObj;
         rndDef = renderingDefObj;
         buffer = bufferObj;
         this.lutProvider = lutProvider;
+        this.processor = processor;
         if (metadata == null) {
             throw new NullPointerException("Expecting not null metadata");
         } else if (rndDef == null) {
@@ -396,7 +425,7 @@ public class Renderer {
         }
 
         // Create an appropriate rendering strategy.
-        renderingStrategy = RenderingStrategy.makeNew(rndDef.getModel());
+        renderingStrategy = RenderingStrategy.makeNew(rndDef.getModel(), processor);
         
         // Examine the metadata we've been given and enable optimizations.
         checkOptimizations();
@@ -424,7 +453,7 @@ public class Renderer {
     public void setModel(RenderingModel model)
     {
         rndDef.setModel(model);
-        renderingStrategy = RenderingStrategy.makeNew(model);
+        renderingStrategy = RenderingStrategy.makeNew(model, processor);
     }
 
     /**


### PR DESCRIPTION
An externally defined service can now be used to take part in server thread pooling.