### PR TITLE
unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,12 @@ dependencies {
 }
 
 test {
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+    }
     // enable TestNG support (default is JUnit)
     useTestNG() {
         suites "src/test/resources/unit.testng.xml"
     }
+    dependsOn cleanTest
 }


### PR DESCRIPTION
display test output in console and do not cache
Check that the output is displayed in the console every time
``gradle test`` is run