### PR TITLE
Prepare build for releasing OMERO 5.6.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.7-SNAPSHOT"
+version = "5.5.7"
 
 repositories {
     mavenLocal()
@@ -19,7 +19,7 @@ java {
 dependencies {
     testImplementation("org.testng:testng:6.14.2")
 
-    api("org.openmicroscopy:omero-romio:5.6.1")
+    api("org.openmicroscopy:omero-romio:5.6.2")
 
     // Keep these from being exposed to child projects
     implementation("commons-lang:commons-lang:2.6")


### PR DESCRIPTION
Adjust build to correspond with latest release notes in #14.

--exclude for now