### PR TITLE
Bump org.openmicroscopy.project from 5.7.2 to 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java-library"
-    id "org.openmicroscopy.project" version "5.7.2"
+    id "org.openmicroscopy.project" version "6.0.0"
 }
 
 group = "org.openmicroscopy"
@@ -9,6 +9,19 @@ version = "5.6.4-SNAPSHOT"
 repositories {
     mavenLocal()
     mavenCentral()
+    mavenCentral()
+    maven {
+        url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases/'
+    }
+    maven {
+        url 'https://artifacts.unidata.ucar.edu/repository/unidata-releases/'
+    }
+    maven {
+        url 'https://maven.scijava.org/repository/thirdparty/'
+    }
+    maven {
+        url 'https://artifacts.openmicroscopy.org/artifactory/ome.external/'
+    }
 }
 
 compileJava {


### PR DESCRIPTION
See https://github.com/ome/omero-artifact-plugin/releases/tag/v6.0.0
Explicitly declare OME artifactory, Unidata and Scijava repositories