### PR TITLE
Bump org.openmicroscopy:omero-romio from 5.8.3 to 5.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compileJava {
 dependencies {
     testImplementation("org.testng:testng:7.5")
 
-    api("org.openmicroscopy:omero-romio:5.8.3")
+    api("org.openmicroscopy:omero-romio:5.8.4")
 
     // Keep these from being exposed to child projects
     implementation("org.apache.commons:commons-lang3:3.18.0")


### PR DESCRIPTION
See https://github.com/ome/omero-romio/releases/tag/v5.8.4