### PR TITLE
Allow Client to Provide ExecutorService

### DIFF
--- a/src/main/java/omeis/providers/re/HSBStrategy.java
+++ b/src/main/java/omeis/providers/re/HSBStrategy.java
@@ -62,7 +62,18 @@ class HSBStrategy extends RenderingStrategy {
 	
     /** The logger for this particular class */
     private static Logger log = LoggerFactory.getLogger(HSBStrategy.class);
-    
+
+    /** Shared thread pool */
+    ExecutorService processor;
+
+    public HSBStrategy(ExecutorService processor) {
+        this.processor = processor;
+    }
+
+    public HSBStrategy(Object obj) {
+        this.processor = Executors.newCachedThreadPool();
+    }
+
     /**
      * Retrieves the maximum number of reasonable tasks to schedule based on
      * image size and <i>maxTasks</i>.
@@ -329,7 +340,6 @@ class HSBStrategy extends RenderingStrategy {
         performanceStats.startRendering();
         int n = tasks.length;
         Future[] rndTskFutures = new Future[n]; // [0] unused.
-        ExecutorService processor = Executors.newCachedThreadPool();
 
         while (0 < --n) {
             rndTskFutures[n] = processor.submit(tasks[n]);

--- a/src/main/java/omeis/providers/re/HSBStrategy.java
+++ b/src/main/java/omeis/providers/re/HSBStrategy.java
@@ -63,15 +63,8 @@ class HSBStrategy extends RenderingStrategy {
     /** The logger for this particular class */
     private static Logger log = LoggerFactory.getLogger(HSBStrategy.class);
 
-    /** Shared thread pool */
-    ExecutorService processor;
-
     public HSBStrategy(ExecutorService processor) {
         this.processor = processor;
-    }
-
-    public HSBStrategy(Object obj) {
-        this.processor = Executors.newCachedThreadPool();
     }
 
     /**
@@ -361,9 +354,6 @@ class HSBStrategy extends RenderingStrategy {
                 throw new RuntimeException(e);
             }
         }
-
-        // Shutdown the task processor
-        processor.shutdown();
 
         // End the performance metrics for this rendering event.
         performanceStats.endRendering();


### PR DESCRIPTION
Picks up #10 
Related to https://github.com/glencoesoftware/omero-ms-image-region/issues/50

Previously, when using the `HSBRenderingStrategy`, the class would create its own `ExecutorService` here: 
https://github.com/ome/omero-renderer/blob/5c92fe800165acc0a2a11dd26369fcf0462b6173/src/main/java/omeis/providers/re/HSBStrategy.java#L332

`newCachedThreadPool` returns a `ThreadPoolExecutor` which will create an unbounded number of threads. The combination of having one `ThreadPoolExecutor` per `Renderer` plus that pool always being unlimited in size means that clients can unintentionally create huge number of threads.

This PR changes that by providing the client with the option to create and manage the `ExecutorService`.
With this PR, `Renderer` takes an `ExecutorService` as an argument and passes it through to the `HSBRenderingStrategy` for use in rendering. This means the calling code gets to determine the quantity and properties of the thread pools, and can therefore put hard limits on how many threads might get created. 

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html has good information about how to create and manage `ThreadPoolExecutors` to achieve the desired behavior. 